### PR TITLE
Replace CV link with Presentations in navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -10,7 +10,7 @@
       <nav class="site-nav" aria-label="Main navigation">
         <a href="{{ site.baseurl }}/books/" class="nav-link">Books</a>
         <a href="{{ site.baseurl }}/portfolio.html" class="nav-link">Portfolio</a>
-        <a href="{{ site.baseurl }}/cv-resume.html" target="_blank" class="nav-link">CV</a>
+        <a href="{{ site.baseurl }}/presentations/" class="nav-link">Presentations</a>
         <button class="theme-toggle" id="theme-toggle" aria-label="Toggle theme">
           <span id="theme-toggle-text">Dark</span>
         </button>


### PR DESCRIPTION
Replaces the CV nav link with Presentations. The CV page still exists at /cv-resume.html — just not linked from the nav bar.