### PR TITLE
Update Amazon paperback links — colour and B&W editions live

### DIFF
--- a/books.md
+++ b/books.md
@@ -13,7 +13,7 @@ permalink: /books/
     <p>This book bridges the gap between software architecture principles and the tools Ruby on Rails already ships. It takes the thinking of Robert C. Martin, Neal Ford, Mark Richards, and Kent Beck and applies it to real Ruby on Rails applications — with working code, honest trade-offs, and a companion open-source application you can run yourself.</p>
     <p>Four parts. Eighteen chapters. 378 pages.</p>
     <p>
-      <a href="/modular-rails/">Learn more</a> · <a href="https://www.amazon.co.uk/dp/B0GZL7D53M">Amazon UK</a> · <a href="https://www.amazon.com/dp/B0GZL7D53M">Amazon US</a>
+      <a href="/modular-rails/">Learn more</a> · <a href="https://www.amazon.co.uk/dp/1066649405">Amazon UK</a> · <a href="https://www.amazon.com/dp/1066649405">Amazon US</a>
     </p>
   </div>
 </div>

--- a/modular-rails.md
+++ b/modular-rails.md
@@ -53,8 +53,8 @@ Four parts. Eighteen chapters. From principles to practice to the hard questions
 
 | Format | Price | Link |
 |--------|-------|------|
-| Colour Paperback | $49.99 / £44.99 | Coming soon |
-| B&W Paperback | $29.99 / £24.99 | Coming soon |
+| Colour Paperback | $49.99 / £44.99 | [Amazon UK](https://www.amazon.co.uk/dp/1066649405) · [Amazon US](https://www.amazon.com/dp/1066649405) |
+| B&W Paperback | $29.99 / £24.99 | [Amazon UK](https://www.amazon.co.uk/dp/1066649421) · [Amazon US](https://www.amazon.com/dp/1066649421) |
 | Kindle | $29.99 / £24.99 | [Amazon UK](https://www.amazon.co.uk/dp/B0GZL7D53M) · [Amazon US](https://www.amazon.com/dp/B0GZL7D53M) |
 
 *Also available through bookshops and libraries via IngramSpark.*


### PR DESCRIPTION
Replaces "Coming soon" with actual Amazon links for both paperback editions:

- Colour: UK dp/1066649405, US dp/1066649405
- B&W: UK dp/1066649421, US dp/1066649421

Also updates the Books page main link to point to the colour paperback instead of the Kindle ASIN.