### PR TITLE
Add scheduled publishing for future-dated blog posts

### DIFF
--- a/.github/workflows/scheduled-publish.yml
+++ b/.github/workflows/scheduled-publish.yml
@@ -1,0 +1,27 @@
+name: Scheduled publish
+
+on:
+  schedule:
+    # Runs daily at 06:00 UTC (7am BST)
+    # Offset from :00 to avoid GitHub peak load
+    - cron: '3 6 * * *'
+  workflow_dispatch: # Manual trigger option
+
+jobs:
+  rebuild:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Configure Git
+        run: |
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+      - name: Trigger rebuild
+        run: |
+          git commit --allow-empty -m "Scheduled rebuild — publish pending posts"
+          git push

--- a/_config.yml
+++ b/_config.yml
@@ -10,3 +10,4 @@ github_username:  davidslv
 
 # Build settings
 markdown: kramdown
+future: false


### PR DESCRIPTION
## What this does

Enables scheduling blog posts by merging them with future dates. Posts appear automatically on their scheduled date.

## How it works

1. `future: false` in `_config.yml` — Jekyll skips posts with dates in the future
2. GitHub Actions cron runs daily at 06:03 UTC (7:03am BST)
3. The action pushes an empty commit, triggering a GitHub Pages rebuild
4. Any post whose date has arrived is now included in the build

## Workflow

1. Merge a PR with a post dated e.g. `2026-05-12`
2. Post is invisible until May 12
3. At 06:03 UTC on May 12, the cron triggers a rebuild
4. Post appears on the site

## Setup required after merging

Go to **Settings → Actions → General → Workflow permissions** and select **Read and write permissions**. This allows the action to push the empty commit.

No secrets or PATs needed — uses the built-in `GITHUB_TOKEN`.