### PR TITLE
Add IngramSpark sales link for Roguelike book

### DIFF
--- a/books.md
+++ b/books.md
@@ -29,7 +29,7 @@ permalink: /books/
     <p>This book takes you on a practical journey from your first playable prototype to a complete roguelike game. Based on a real five-year development journey, it teaches you not just how to build a roguelike, but why architectural decisions matter. You'll implement maze generation algorithms, build Entity-Component-System architecture, and create combat, inventory, and AI systems — all from scratch using pure Ruby.</p>
     <p>Five parts. Twenty-two chapters. 163 pages.</p>
     <p>
-      <a href="https://www.amazon.co.uk/dp/B0G1SGN181">Buy on Amazon</a> · <a href="/ruby/game-development/2025/11/08/vanilla-roguelike.html">Read the story behind the book</a>
+      <a href="https://www.amazon.co.uk/dp/B0G1SGN181">Buy on Amazon</a> · <a href="https://shop.ingramspark.com/b/084?params=YvsSxC2CpPMq7ScV1fsmNManFt9uhNouQ3BjXqz4aBO">Buy on IngramSpark</a> · <a href="/ruby/game-development/2025/11/08/vanilla-roguelike.html">Read the story behind the book</a>
     </p>
   </div>
 </div>


### PR DESCRIPTION
## Summary
- Adds a "Buy on IngramSpark" link alongside the existing Amazon link on the Roguelike book entry on `/books`.

## Test plan
- [ ] Visit `/books` and verify the IngramSpark link renders next to "Buy on Amazon"
- [ ] Confirm the link opens the correct IngramSpark product page