### PR TITLE
SEO: per-chapter descriptions + Book/Article schema for Modular Rails

### DIFF
--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -1,0 +1,7 @@
+# Author metadata for jekyll-seo-tag. Keyed by the author name used in
+# `author:` (config default + post front matter). Lets seo-tag emit the
+# correct twitter:creator handle without changing the byline string.
+David Silva:
+  name: David Silva
+  twitter: davidslv
+  url: https://davidslv.uk

--- a/_layouts/book.html
+++ b/_layouts/book.html
@@ -6,6 +6,29 @@ layout: default
 {%- assign current = nil -%}
 {%- for c in chapters -%}{%- if c.url == page.url -%}{%- assign current = c -%}{%- break -%}{%- endif -%}{%- endfor -%}
 
+{%- comment -%} Per-chapter structured data: an Article that is part of the Book. {%- endcomment -%}
+{%- if current and current.type != 'part-divider' and current.type != 'front-matter' -%}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": {{ page.title | jsonify }},
+  {% if page.description %}"description": {{ page.description | jsonify }},
+  {% endif %}"url": {{ page.url | absolute_url | jsonify }},
+  "inLanguage": "en",
+  "isAccessibleForFree": true,
+  "author": { "@type": "Person", "name": {{ book.author | jsonify }}, "url": "https://davidslv.uk" },
+  "isPartOf": {
+    "@type": "Book",
+    "name": {{ book.title | jsonify }},
+    "url": {{ book.home | absolute_url | jsonify }},
+    "isbn": {{ book.buy.isbn | jsonify }},
+    "author": { "@type": "Person", "name": {{ book.author | jsonify }} }
+  }
+}
+</script>
+{%- endif -%}
+
 {%- capture prevnext -%}
 {%- if current.prev or current.next -%}
 <nav class="book-prevnext" aria-label="Chapter navigation">

--- a/books/modular-rails/chapter-01-why-architecture-matters.md
+++ b/books/modular-rails/chapter-01-why-architecture-matters.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Why Architecture Matters"
 permalink: /books/modular-rails/chapter-01-why-architecture-matters/
+description: "Why the cost of change in a growing Rails app climbs exponentially — and how architectural boundaries keep a large Rails monolith maintainable."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-02-clean-architecture-for-rubyists.md
+++ b/books/modular-rails/chapter-02-clean-architecture-for-rubyists.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Clean Architecture for Rubyists"
 permalink: /books/modular-rails/chapter-02-clean-architecture-for-rubyists/
+description: "Scaling Robert C. Martin's SOLID and component principles from Ruby classes up to Rails engines — Clean Architecture applied for Rubyists."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-03-the-hard-parts.md
+++ b/books/modular-rails/chapter-03-the-hard-parts.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "The Hard Parts — Reasoning About Trade-offs"
 permalink: /books/modular-rails/chapter-03-the-hard-parts/
+description: "Architecture is trade-off analysis, not best practices — a framework for reasoning about Rails engine decisions, from Ford & Richards' The Hard Parts."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-04-extreme-programming-and-emergent-design.md
+++ b/books/modular-rails/chapter-04-extreme-programming-and-emergent-design.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Extreme Programming and Emergent Design"
 permalink: /books/modular-rails/chapter-04-extreme-programming-and-emergent-design/
+description: "Why solid Rails architecture emerges through feedback and simple design rather than big up-front planning — Kent Beck's XP applied to engines."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-05-rails-engines-from-the-inside-out.md
+++ b/books/modular-rails/chapter-05-rails-engines-from-the-inside-out.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Rails Engines from the Inside Out"
 permalink: /books/modular-rails/chapter-05-rails-engines-from-the-inside-out/
+description: "How Rails engines really work, read from the Rails 8.1 source: the boot process, the inheritance chain, and why your app is itself an engine."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-06-namespace-isolation.md
+++ b/books/modular-rails/chapter-06-namespace-isolation.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Namespace Isolation"
 permalink: /books/modular-rails/chapter-06-namespace-isolation/
+description: "What isolate_namespace actually does, traced line by line through the Rails 8.1 source — how engine boundaries, tables and route helpers stay separate."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-07-building-your-first-engine.md
+++ b/books/modular-rails/chapter-07-building-your-first-engine.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Building Your First Engine"
 permalink: /books/modular-rails/chapter-07-building-your-first-engine/
+description: "Build a real notifications engine from the terminal up: generating, mounting, wiring and testing your first mountable Rails engine, no theory."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-08-engine-integration-patterns.md
+++ b/books/modular-rails/chapter-08-engine-integration-patterns.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Engine Integration Patterns"
 permalink: /books/modular-rails/chapter-08-engine-integration-patterns/
+description: "Let a Rails engine talk to the host app and other engines without breaking its boundaries — concerns, dependency injection and event-based patterns."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-09-identifying-boundaries.md
+++ b/books/modular-rails/chapter-09-identifying-boundaries.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Identifying Boundaries in an Existing Application"
 permalink: /books/modular-rails/chapter-09-identifying-boundaries/
+description: "Where to draw boundaries in a 150-model Rails monolith — using git history, coupling signals and domain analysis to find the seams that are really there."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-10-extracting-your-first-engine.md
+++ b/books/modular-rails/chapter-10-extracting-your-first-engine.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Extracting Your First Engine"
 permalink: /books/modular-rails/chapter-10-extracting-your-first-engine/
+description: "A complete walkthrough of extracting a billing domain from a Rails monolith into a mountable engine: models, migrations, controllers, routes and tests."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-11-managing-inter-engine-dependencies.md
+++ b/books/modular-rails/chapter-11-managing-inter-engine-dependencies.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Managing Inter-Engine Dependencies"
 permalink: /books/modular-rails/chapter-11-managing-inter-engine-dependencies/
+description: "Keep your engine dependency graph acyclic — declaring dependencies explicitly and avoiding cycles as a Rails modular monolith grows past five engines."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-12-data-ownership.md
+++ b/books/modular-rails/chapter-12-data-ownership.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Data Ownership and the Database Question"
 permalink: /books/modular-rails/chapter-12-data-ownership/
+description: "Who owns a table once its domain becomes an engine? Data ownership, shared databases and migration strategy for a Rails modular monolith."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-13-testing-strategy.md
+++ b/books/modular-rails/chapter-13-testing-strategy.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Testing Strategy for a Modular Monolith"
 permalink: /books/modular-rails/chapter-13-testing-strategy/
+description: "Cut a 40-minute Rails test suite to 4 by testing engines in isolation — the testing pyramid and boundary-driven test strategy for a modular monolith."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-14-team-workflow.md
+++ b/books/modular-rails/chapter-14-team-workflow.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Team Workflow and Developer Experience"
 permalink: /books/modular-rails/chapter-14-team-workflow/
+description: "The daily workflows that keep a modular Rails monolith pleasant to work in — developing separate-repo engines locally, path gems and developer experience."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-15-when-engines-are-wrong.md
+++ b/books/modular-rails/chapter-15-when-engines-are-wrong.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "When Engines Are the Wrong Tool"
 permalink: /books/modular-rails/chapter-15-when-engines-are-wrong/
+description: "When Rails engines are the wrong tool: apps that are too small, premature boundaries, and the real costs of modularising before you need to."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-16-engines-vs-alternatives.md
+++ b/books/modular-rails/chapter-16-engines-vs-alternatives.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Engines vs the Alternatives"
 permalink: /books/modular-rails/chapter-16-engines-vs-alternatives/
+description: "Rails engines vs Packwerk, gems and namespaced modules — a side-by-side comparison to choose the right modularisation tool for your context."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-17-the-microservices-question.md
+++ b/books/modular-rails/chapter-17-the-microservices-question.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "The Microservices Question"
 permalink: /books/modular-rails/chapter-17-the-microservices-question/
+description: "Modular monolith vs microservices for Rails — when distribution is genuinely necessary, with the Amazon Prime Video case study and DHH's take."
 ---
 {% raw %}
 

--- a/books/modular-rails/chapter-18-evolving-your-architecture.md
+++ b/books/modular-rails/chapter-18-evolving-your-architecture.md
@@ -3,6 +3,7 @@ layout: book
 book: modular_rails
 title: "Evolving Your Architecture Over Time"
 permalink: /books/modular-rails/chapter-18-evolving-your-architecture/
+description: "Architecture is a journey, not a destination — how to recognise when your Rails architecture needs to change and evolve it without a full rewrite."
 ---
 {% raw %}
 


### PR DESCRIPTION
## What
Three on-page SEO fixes for the free Modular Rails web edition, so each chapter ranks as its own entry point.

- **Unique per-chapter `description`** on all 18 chapters (was: every chapter inherited the sitewide bio as its meta + og:description).
- **Per-chapter `Article` + `isPartOf Book` JSON-LD** emitted from `_layouts/book.html` for every chapter and appendix (22 pages). Carries the book ISBN, links each chapter to the book.
- **Fix `twitter:creator`** — `_data/authors.yml` makes jekyll-seo-tag resolve it to `@davidslv` (was the malformed `@David Silva`). Byline string untouched.

## Verified against the rendered build
- `jekyll build` passes; 44 JSON-LD blocks parse, 0 errors; all 18 front matters parse as valid YAML.
- ch.6 / ch.13 confirmed to have distinct descriptions; landing-page Book schema untouched.
- `_site` (tracked build output) deliberately excluded — source-only diff. Regenerate via the usual rebuild to publish.

## Durability note
The chapter `.md` files are generated by `quire build`. (B) and (C) live in the layout/`_data` and are permanent, but (A)'s front-matter descriptions are made durable in a companion change to the quire source (`ruby-architecture`) so rebuilds keep them.